### PR TITLE
Implement admin interface with orders report

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -84,6 +84,10 @@ class AuthWrapper extends StatelessWidget {
         }
 
         if (snapshot.hasData && snapshot.data != null) {
+          final user = snapshot.data!;
+          if (user.email == 'fabricio99cv@gmail.com') {
+            return const AdminDashboard();
+          }
           return const MainScreen();
         }
 

--- a/lib/services/ProductService.dart
+++ b/lib/services/ProductService.dart
@@ -5,8 +5,11 @@ class ProductService {
       .collection('productos');
 
   // Regex para validaciones
-  final RegExp _descriptionRegex = RegExp(r'^[a-zA-Z0-9 .,!?()-]+$');
-  final RegExp _nameRegex = RegExp(r'^[a-zA-Z0-9 ]+$');
+  // Se incluyen caracteres acentuados y la ñ para admitir español
+  final RegExp _descriptionRegex =
+      RegExp(r'^[a-zA-ZÁÉÍÓÚÜáéíóúüñÑ0-9 .,!?()¡¿-]+$');
+  final RegExp _nameRegex =
+      RegExp(r'^[a-zA-ZÁÉÍÓÚÜáéíóúüñÑ0-9 ]+$');
   final RegExp _urlRegex = RegExp(
     r'^https?:\/\/.*\.(jpeg|jpg|gif|png)(\?.*)?$',
     caseSensitive: false,

--- a/lib/widgets/admin/orders_report.dart
+++ b/lib/widgets/admin/orders_report.dart
@@ -1,0 +1,52 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class OrdersReport extends StatelessWidget {
+  const OrdersReport({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ordersStream = FirebaseFirestore.instance
+        .collectionGroup('purchaseHistory')
+        .orderBy('fechaCompra', descending: true)
+        .snapshots();
+
+    return StreamBuilder<QuerySnapshot>(
+      stream: ordersStream,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+          return const Center(child: Text('No hay pedidos'));
+        }
+        final docs = snapshot.data!.docs;
+        return ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: docs.length,
+          itemBuilder: (context, index) {
+            final data = docs[index].data() as Map<String, dynamic>;
+            final orderId = docs[index].id;
+            final timestamp = data['fechaCompra'] as Timestamp?;
+            final date = timestamp != null
+                ? DateFormat('dd/MM/yyyy HH:mm').format(timestamp.toDate())
+                : 'Sin fecha';
+            final total = data['total']?.toString() ?? '0';
+            final items = data['cantidadItems']?.toString() ?? '0';
+            final userId = docs[index].reference.parent.parent?.id ?? '';
+            return Card(
+              margin: const EdgeInsets.only(bottom: 12),
+              child: ListTile(
+                leading: const Icon(Icons.receipt_long),
+                title: Text('Orden #$orderId'),
+                subtitle: Text('Usuario: $userId\nTotal: S/ $total - $items items'),
+                trailing: Text(date),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   geolocator: ^11.0.0
   http: ^0.13.6
   firebase_auth: ^5.5.4
+  firebase_storage: ^11.6.6
   image_picker: ^1.1.2
   image: ^4.5.4
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- add `OrdersReport` widget for viewing purchases from all users
- integrate image picker and Firebase Storage in `AdminDashboard`
- show tab for order report in admin panel
- show admin panel when logging in with specific admin email
- include firebase_storage dependency
- fix product editing, check save results, add admin logout button

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694c036a608321a6a132dd28258f64